### PR TITLE
fix(script): remove output from inside script

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -50,7 +50,7 @@ jobs:
         id: gigid
         run: |
           export FAKE_VALID_TOKEN=fake-valid-token
-          bash src/scripts/upload.sh
+          bash src/scripts/upload.sh >> "$GITHUB_OUTPUT"
         env:
           REPO_URL: ${{ github.server_url }}/${{ github.repository }}
           TOKEN: FAKE_VALID_TOKEN

--- a/src/scripts/upload.sh
+++ b/src/scripts/upload.sh
@@ -21,4 +21,5 @@ curl -X POST \
 
 GIGID=$(cat result.json | jq -r .gigid)
 echo "::notice title=CI Issues report::CI_ISSUE_GIGID=$GIGID"
-echo "CI_ISSUE_GIGID=$GIGID" >> "$GITHUB_OUTPUT"
+
+echo "CI_ISSUE_GIGID=$GIGID"


### PR DESCRIPTION
GH_OUTPUT is for CI and it does not exist when running on circle ci, causing it to crash.